### PR TITLE
Add violation checker to policies

### DIFF
--- a/src/main/java/agh/edu/zeuspol/checker/SlaViolationChecker.java
+++ b/src/main/java/agh/edu/zeuspol/checker/SlaViolationChecker.java
@@ -8,7 +8,16 @@ import java.util.List;
 
 public class SlaViolationChecker {
 
-    public boolean check(Sla sla, Rule rule){
+    public static boolean checkRules(Sla sla, List<Rule> rules) {
+        for (Rule rule : rules) {
+            if (!checkRule(sla, rule)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static boolean checkRule(Sla sla, Rule rule){
         for (Rule slaRule: sla.getRules()){
             if (slaRule.subject == rule.subject && slaRule.attribute == rule.attribute){
                 if (slaRule.unit != rule.unit){
@@ -26,7 +35,7 @@ public class SlaViolationChecker {
                     }
                 }
                 else if (slaRule.action == ActionType.BT && rule.action == ActionType.BT){
-                    if (!this.isBetween(slaRule.value, rule.value)){
+                    if (!isBetween(slaRule.value, rule.value)){
                         return true;
                     }
                 }
@@ -60,7 +69,7 @@ public class SlaViolationChecker {
         return false;
     }
 
-    private boolean isBetween(List<Number> span1, List<Number> span2){
+    private static boolean isBetween(List<Number> span1, List<Number> span2){
         if (span1.size() != 2 || span2.size() != 2){
             throw new RuntimeException("Wrong argument number in lists!");
         }

--- a/src/main/java/agh/edu/zeuspol/checker/SlaViolationChecker.java
+++ b/src/main/java/agh/edu/zeuspol/checker/SlaViolationChecker.java
@@ -8,16 +8,17 @@ import java.util.List;
 
 public class SlaViolationChecker {
 
-    public static boolean checkRules(Sla sla, List<Rule> rules) {
+    public static boolean checkRules(List<Rule> rules) {
         for (Rule rule : rules) {
-            if (!checkRule(sla, rule)) {
+            if (!checkRule(rule)) {
                 return false;
             }
         }
         return true;
     }
 
-    public static boolean checkRule(Sla sla, Rule rule){
+    public static boolean checkRule(Rule rule){
+        Sla sla = Sla.getInstance();
         for (Rule slaRule: sla.getRules()){
             if (slaRule.subject == rule.subject && slaRule.attribute == rule.attribute){
                 if (slaRule.unit != rule.unit){

--- a/src/main/java/agh/edu/zeuspol/datastructures/storage/Policies.java
+++ b/src/main/java/agh/edu/zeuspol/datastructures/storage/Policies.java
@@ -25,8 +25,8 @@ public class Policies {
     }
 
     public boolean addRulesSecure(List<Rule> rules){
-        if(!SlaViolationChecker.checkRules(Sla.getInstance(), rules)){
-            this.rules.addAll(rules);
+        if(!SlaViolationChecker.checkRules(rules)){
+            this.addRules(rules);
             return true;
         }
         return false;

--- a/src/main/java/agh/edu/zeuspol/datastructures/storage/Policies.java
+++ b/src/main/java/agh/edu/zeuspol/datastructures/storage/Policies.java
@@ -1,5 +1,6 @@
 package agh.edu.zeuspol.datastructures.storage;
 
+import agh.edu.zeuspol.checker.SlaViolationChecker;
 import agh.edu.zeuspol.datastructures.Rule;
 
 import java.util.ArrayList;
@@ -23,6 +24,14 @@ public class Policies {
         this.rules.addAll(rules);
     }
 
+    public boolean addRulesSecure(List<Rule> rules){
+        if(!SlaViolationChecker.checkRules(Sla.getInstance(), rules)){
+            this.rules.addAll(rules);
+            return true;
+        }
+        return false;
+    }
+
     public void addRule(Rule rule){
         this.rules.add(rule);
     }
@@ -41,8 +50,6 @@ public class Policies {
     public List<Rule> getRules() {
         return new ArrayList<>(rules);
     }
-
-
 
 
     @Override

--- a/src/main/java/agh/edu/zeuspol/datastructures/storage/Sla.java
+++ b/src/main/java/agh/edu/zeuspol/datastructures/storage/Sla.java
@@ -48,6 +48,10 @@ public class Sla {
         return null;
     }
 
+    public void removeRules(){
+        this.rules.clear();
+    }
+
     public NotificationRule removeNotificationRule(long id){
         for(NotificationRule notificationRule : notificationRules){
             if(notificationRule.id == id){
@@ -56,6 +60,15 @@ public class Sla {
             }
         }
         return null;
+    }
+
+    public void removeNotificationRules(){
+        this.notificationRules.clear();
+    }
+
+    public void clearSla(){
+        removeRules();
+        removeNotificationRules();
     }
 
     public List<Rule> getRules() {

--- a/src/main/java/agh/edu/zeuspol/endpoints/PoliciesEndpoints.java
+++ b/src/main/java/agh/edu/zeuspol/endpoints/PoliciesEndpoints.java
@@ -23,15 +23,19 @@ public class PoliciesEndpoints {
 
         //add policies to storage class
         Policies policies = Policies.getInstance();
-        policies.addRules(rules);
-
-        //string response
-        return "Policies updated successfully";
+        //INSECURE !!!!
+//        policies.addRules(rules);
+        //SECURE c:
+        if(policies.addRulesSecure(rules)){
+            return "Policies updated successfully!";
+        }
+        return "Policies updated unsuccessfully! One or more rules are not violent with SLA!";
     }
 
     @GetMapping("getPolicies")
     public String getPolicies(){
         Policies policies = Policies.getInstance();
+        //TODO -> return JSON
         return policies.toString();
     }
 

--- a/src/main/java/agh/edu/zeuspol/endpoints/SlaEndpoints.java
+++ b/src/main/java/agh/edu/zeuspol/endpoints/SlaEndpoints.java
@@ -29,12 +29,13 @@ public class SlaEndpoints {
         sla.addNotificationRules(notificationRules);
 
         //string response
-        return "SLA updated successfully";
+        return "SLA updated successfully!";
     }
 
     @GetMapping("/getSla")
     public String getSla(){
         Sla sla = Sla.getInstance();
+        //TODO -> return JSON
         return sla.toString();
     }
 

--- a/src/test/java/agh/edu/zeuspol/SlaViolationCheckerTests.java
+++ b/src/test/java/agh/edu/zeuspol/SlaViolationCheckerTests.java
@@ -14,95 +14,122 @@ import static org.junit.jupiter.api.Assertions.*;
 public class SlaViolationCheckerTests {
 
 
-    private final SlaViolationChecker checker = new SlaViolationChecker();
 
     @Test
     public void testCheck_NoViolation() {
         Rule slaRule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, Collections.singletonList(10), UnitType.BYTE, ActionType.EQ);
-        Sla sla = new Sla(Collections.singletonList(slaRule), Collections.emptyList());
+
+        Sla sla = Sla.getInstance();
+        sla.clearSla();
+        sla.addRule(slaRule);
 
         Rule rule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, Collections.singletonList(10), UnitType.BYTE, ActionType.EQ);
 
-        assertFalse(checker.check(sla, rule));
+        assertFalse(SlaViolationChecker.checkRule(sla, rule));
+
     }
 
     @Test
     public void testCheck_ViolationDifferentUnits() {
         Rule slaRule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, Collections.singletonList(10), UnitType.BYTE, ActionType.EQ);
-        Sla sla = new Sla(Collections.singletonList(slaRule), Collections.emptyList());
+
+        Sla sla = Sla.getInstance();
+        sla.clearSla();
+        sla.addRule(slaRule);
 
         Rule rule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, Collections.singletonList(10), UnitType.NUMBER, ActionType.EQ);
 
-        assertThrows(IllegalArgumentException.class, () -> checker.check(sla, rule));
+        assertThrows(IllegalArgumentException.class, () -> SlaViolationChecker.checkRule(sla, rule));
     }
 
     @Test
     public void testCheck_ViolationDifferentActionTypes() {
         Rule slaRule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, Collections.singletonList(10), UnitType.BYTE, ActionType.LT);
-        Sla sla = new Sla(Collections.singletonList(slaRule), Collections.emptyList());
+
+        Sla sla = Sla.getInstance();
+        sla.clearSla();
+        sla.addRule(slaRule);
 
         Rule rule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, Collections.singletonList(11), UnitType.BYTE, ActionType.GT);
 
-        assertTrue(checker.check(sla, rule));
+        assertTrue(SlaViolationChecker.checkRule(sla, rule));
     }
 
     @Test
     public void testCheck_BetweenNoViolation() {
         Rule slaRule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, Arrays.asList(5, 15), UnitType.BYTE, ActionType.BT);
-        Sla sla = new Sla(Collections.singletonList(slaRule), Collections.emptyList());
+
+        Sla sla = Sla.getInstance();
+        sla.clearSla();
+        sla.addRule(slaRule);
 
         Rule rule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, Arrays.asList(6, 14), UnitType.BYTE, ActionType.BT);
 
-        assertFalse(checker.check(sla, rule));
+        assertFalse(SlaViolationChecker.checkRule(sla, rule));
     }
 
     @Test
     public void testCheck_BetweenViolation() {
         Rule slaRule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, Arrays.asList(5, 15), UnitType.BYTE, ActionType.BT);
-        Sla sla = new Sla(Collections.singletonList(slaRule), Collections.emptyList());
+
+        Sla sla = Sla.getInstance();
+        sla.clearSla();
+        sla.addRule(slaRule);
 
         Rule rule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, Arrays.asList(16, 20), UnitType.BYTE, ActionType.BT);
 
-        assertTrue(checker.check(sla, rule));
+        assertTrue(SlaViolationChecker.checkRule(sla, rule));
     }
 
     @Test
     public void testCheck_MixedActionsNoViolation() {
         Rule slaRule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, Collections.singletonList(10), UnitType.BYTE, ActionType.GT);
-        Sla sla = new Sla(Collections.singletonList(slaRule), Collections.emptyList());
+
+        Sla sla = Sla.getInstance();
+        sla.clearSla();
+        sla.addRule(slaRule);
 
         Rule rule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, Arrays.asList(11, 20), UnitType.BYTE, ActionType.BT);
 
-        assertFalse(checker.check(sla, rule));
+        assertFalse(SlaViolationChecker.checkRule(sla, rule));
     }
 
     @Test
     public void testCheck_MixedActionsViolation() {
         Rule slaRule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, Collections.singletonList(10), UnitType.BYTE, ActionType.GT);
-        Sla sla = new Sla(Collections.singletonList(slaRule), Collections.emptyList());
+
+        Sla sla = Sla.getInstance();
+        sla.clearSla();
+        sla.addRule(slaRule);
 
         Rule rule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, Arrays.asList(5, 8), UnitType.BYTE, ActionType.BT);
 
-        assertTrue(checker.check(sla, rule));
+        assertTrue(SlaViolationChecker.checkRule(sla, rule));
     }
 
     @Test
     public void testCheck_MixedActionsNoViolation2() {
         Rule slaRule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, Arrays.asList(10, 15), UnitType.BYTE, ActionType.BT);
-        Sla sla = new Sla(Collections.singletonList(slaRule), Collections.emptyList());
+
+        Sla sla = Sla.getInstance();
+        sla.clearSla();
+        sla.addRule(slaRule);
 
         Rule rule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, List.of(12), UnitType.BYTE, ActionType.GT);
 
-        assertFalse(checker.check(sla, rule));
+        assertFalse(SlaViolationChecker.checkRule(sla, rule));
     }
 
     @Test
     public void testCheck_MixedActionsViolation2() {
         Rule slaRule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, Arrays.asList(10, 15), UnitType.BYTE, ActionType.BT);
-        Sla sla = new Sla(Collections.singletonList(slaRule), Collections.emptyList());
+
+        Sla sla = Sla.getInstance();
+        sla.clearSla();
+        sla.addRule(slaRule);
 
         Rule rule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, List.of(16), UnitType.BYTE, ActionType.GT);
 
-        assertTrue(checker.check(sla, rule));
+        assertTrue(SlaViolationChecker.checkRule(sla, rule));
     }
 }

--- a/src/test/java/agh/edu/zeuspol/SlaViolationCheckerTests.java
+++ b/src/test/java/agh/edu/zeuspol/SlaViolationCheckerTests.java
@@ -25,7 +25,10 @@ public class SlaViolationCheckerTests {
 
         Rule rule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, Collections.singletonList(10), UnitType.BYTE, ActionType.EQ);
 
-        assertFalse(SlaViolationChecker.checkRule(sla, rule));
+        assertFalse(SlaViolationChecker.checkRule(rule));
+
+
+        sla.clearSla();
 
     }
 
@@ -39,7 +42,10 @@ public class SlaViolationCheckerTests {
 
         Rule rule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, Collections.singletonList(10), UnitType.NUMBER, ActionType.EQ);
 
-        assertThrows(IllegalArgumentException.class, () -> SlaViolationChecker.checkRule(sla, rule));
+        assertThrows(IllegalArgumentException.class, () -> SlaViolationChecker.checkRule(rule));
+
+        sla.clearSla();
+
     }
 
     @Test
@@ -52,7 +58,10 @@ public class SlaViolationCheckerTests {
 
         Rule rule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, Collections.singletonList(11), UnitType.BYTE, ActionType.GT);
 
-        assertTrue(SlaViolationChecker.checkRule(sla, rule));
+        assertTrue(SlaViolationChecker.checkRule(rule));
+
+
+        sla.clearSla();
     }
 
     @Test
@@ -65,7 +74,10 @@ public class SlaViolationCheckerTests {
 
         Rule rule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, Arrays.asList(6, 14), UnitType.BYTE, ActionType.BT);
 
-        assertFalse(SlaViolationChecker.checkRule(sla, rule));
+        assertFalse(SlaViolationChecker.checkRule(rule));
+
+
+        sla.clearSla();
     }
 
     @Test
@@ -78,7 +90,10 @@ public class SlaViolationCheckerTests {
 
         Rule rule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, Arrays.asList(16, 20), UnitType.BYTE, ActionType.BT);
 
-        assertTrue(SlaViolationChecker.checkRule(sla, rule));
+        assertTrue(SlaViolationChecker.checkRule(rule));
+
+
+        sla.clearSla();
     }
 
     @Test
@@ -91,7 +106,10 @@ public class SlaViolationCheckerTests {
 
         Rule rule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, Arrays.asList(11, 20), UnitType.BYTE, ActionType.BT);
 
-        assertFalse(SlaViolationChecker.checkRule(sla, rule));
+        assertFalse(SlaViolationChecker.checkRule(rule));
+
+
+        sla.clearSla();
     }
 
     @Test
@@ -104,7 +122,10 @@ public class SlaViolationCheckerTests {
 
         Rule rule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, Arrays.asList(5, 8), UnitType.BYTE, ActionType.BT);
 
-        assertTrue(SlaViolationChecker.checkRule(sla, rule));
+        assertTrue(SlaViolationChecker.checkRule(rule));
+
+
+        sla.clearSla();
     }
 
     @Test
@@ -117,7 +138,10 @@ public class SlaViolationCheckerTests {
 
         Rule rule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, List.of(12), UnitType.BYTE, ActionType.GT);
 
-        assertFalse(SlaViolationChecker.checkRule(sla, rule));
+        assertFalse(SlaViolationChecker.checkRule(rule));
+
+
+        sla.clearSla();
     }
 
     @Test
@@ -130,6 +154,9 @@ public class SlaViolationCheckerTests {
 
         Rule rule = new Rule(RuleAttribute.UPTIME, RuleSubject.CPU, List.of(16), UnitType.BYTE, ActionType.GT);
 
-        assertTrue(SlaViolationChecker.checkRule(sla, rule));
+        assertTrue(SlaViolationChecker.checkRule(rule));
+
+
+        sla.clearSla();
     }
 }


### PR DESCRIPTION
# Updated classes
## ```Sla``` class
### ```clearSla()``` method
Method removes rules and notification rules from SLA.
## ```Policies``` class
### ```addRulesSecure()``` method
Method adds policies with initial check if they are in accordance with given SLA.
## ```SlaViolationChecker``` class
### ```checkRule()``` method
Modified to use Singleton version of ```Sla``` class.
### ```checkRules()``` method
Method uses ```checkRule()``` method to check if all rules from list are checked.
#Tests
Tests were changed, because of changes in ```SlaViolationChecker```