### PR TITLE
Fixed issue with path to drools files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ docker-build-local:
 	docker build --no-cache -t zeuspol .
 
 docker-build-local-windows:
-	minikube -p minikube docker-env --shell powershell | Invoke-Expression
+	powershell -Command "minikube -p minikube docker-env --shell powershell | Invoke-Expression"
 	mvn clean install
 	docker build --no-cache -t zeuspol .
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,12 @@
 
 		<dependency>
 			<groupId>org.drools</groupId>
+			<artifactId>drools-xml-support</artifactId>
+			<version>${drools-version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.drools</groupId>
 			<artifactId>drools-bom</artifactId>
 			<type>pom</type>
 			<version>${drools-version}</version>

--- a/src/main/java/agh/edu/zeuspol/ZeuspolApplication.java
+++ b/src/main/java/agh/edu/zeuspol/ZeuspolApplication.java
@@ -1,5 +1,4 @@
 package agh.edu.zeuspol;
-
 import agh.edu.zeuspol.drools.DroolsClass;
 import agh.edu.zeuspol.iofile.JSONLoader;
 import agh.edu.zeuspol.services.HephaestusQueryService;
@@ -8,14 +7,12 @@ import io.github.hephaestusmetrics.model.metrics.Metric;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.core.io.ResourceLoader;
-
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.List;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+
 
 @SpringBootApplication
 public class ZeuspolApplication {
@@ -87,7 +84,9 @@ public class ZeuspolApplication {
 	private static void mainLoop() {
 		HephaestusQueryService metricsService = context.getBean(HephaestusQueryService.class);
 		ThemisService themisService = context.getBean(ThemisService.class);
-//		DroolsClass drools = new DroolsClass("drools");
+		DroolsClass drools = new DroolsClass("ZeusSession");
+
+		drools.fire(null);
 		//infinite loop of mainLoops
 		while(true){
 		//if app should be running, then run main loop

--- a/src/main/java/agh/edu/zeuspol/drools/DroolsClass.java
+++ b/src/main/java/agh/edu/zeuspol/drools/DroolsClass.java
@@ -1,52 +1,25 @@
 package agh.edu.zeuspol.drools;
 import io.github.hephaestusmetrics.model.metrics.Metric;
 import org.kie.api.KieServices;
-import org.kie.api.builder.KieBuilder;
-import org.kie.api.builder.KieFileSystem;
-import org.kie.api.builder.KieRepository;
-import org.kie.api.builder.ReleaseId;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
-import org.kie.internal.io.ResourceFactory;
-import java.io.IOException;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 
 public class DroolsClass {
-    private final KieServices kieServices = KieServices.Factory.get();
+    private final KieServices kieServices = KieServices.get();
+    private String sessionName;
 
-    private String rulesDirectory;
-
-    public DroolsClass(String rulesDirectory){
-        this.rulesDirectory = rulesDirectory;
-    }
-
-    private KieFileSystem getKieFileSystem() {
-        KieFileSystem kieFileSystem = kieServices.newKieFileSystem();
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(Paths.get(this.rulesDirectory))) {
-            for (Path path : stream) {
-                kieFileSystem.write(ResourceFactory.newClassPathResource("drools/" + path.getFileName().toString()));
-            }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        return kieFileSystem;
+    /**
+     * @param  sessionName  can be found in resource/META-INF/kmodule.xml
+     */
+    public DroolsClass(String sessionName){
+        this.sessionName = sessionName;
     }
 
     public KieSession getKieSession() {
-        KieBuilder kb = kieServices.newKieBuilder(getKieFileSystem());
-        kb.buildAll();
-
-        KieRepository kieRepository = kieServices.getRepository();
-        ReleaseId krDefaultReleaseId = kieRepository.getDefaultReleaseId();
-        KieContainer kieContainer = kieServices.newKieContainer(krDefaultReleaseId);
-
-        return kieContainer.newKieSession();
+        KieContainer kc = this.kieServices.getKieClasspathContainer();
+        return kc.newKieSession(this.sessionName);
     }
-
     public void fire(Metric metric){
         KieSession kieSession = this.getKieSession();
         kieSession.insert(metric);

--- a/src/main/resources/META-INF/kmodule.xml
+++ b/src/main/resources/META-INF/kmodule.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kmodule xmlns="http://www.drools.org/xsd/kmodule">
+    <kbase name="agh.edu.zeuspol" packages="drools">
+        <ksession name="ZeusSession"/>
+    </kbase>
+</kmodule>

--- a/src/main/resources/drools/test.drl
+++ b/src/main/resources/drools/test.drl
@@ -1,11 +1,13 @@
+package drools;
+
+
 import agh.edu.zeuspol.datastructures.Rule;
 
 
 dialect  "mvel"
 
-rule "Suggest Manager Role"
+rule "Test rule"
     when
-        Rule()
     then
-        System.out.println("Rule fired");
+        System.out.println("Test rule fired");
 end

--- a/src/test/java/agh/edu/zeuspol/DroolsTest.java
+++ b/src/test/java/agh/edu/zeuspol/DroolsTest.java
@@ -1,6 +1,5 @@
 package agh.edu.zeuspol;
 
-import agh.edu.zeuspol.datastructures.Rule;
 import agh.edu.zeuspol.drools.DroolsClass;
 import io.github.hephaestusmetrics.model.metrics.Metric;
 import org.junit.jupiter.api.Test;
@@ -10,8 +9,12 @@ public class DroolsTest {
 
     @Test
     public void droolsTest(){
-        DroolsClass droolsClass = new DroolsClass("src/test/resources/drools");
+        DroolsClass droolsClass = new DroolsClass("ZeusSession");
 
-        droolsClass.fire(Mockito.mock(Metric.class));
+        Metric m = Mockito.mock(Metric.class);
+        Mockito.when(m.getValue()).thenReturn(0.7);
+        Mockito.when(m.getName()).thenReturn("container_cpu_usage_seconds_total");
+
+        droolsClass.fire(m);
     }
 }

--- a/src/test/resources/META-INF/kmodule.xml
+++ b/src/test/resources/META-INF/kmodule.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kmodule xmlns="http://www.drools.org/xsd/kmodule">
+    <kbase name="agh.edu.zeuspol" packages="drools">
+        <ksession name="ZeusSession"/>
+    </kbase>
+</kmodule>

--- a/src/test/resources/drools/metric2.drl
+++ b/src/test/resources/drools/metric2.drl
@@ -4,9 +4,9 @@ import io.github.hephaestusmetrics.model.metrics.Metric;
 
 dialect  "mvel"
 
-rule "Metric1 test"
+rule "Metric2 test"
     when
         Metric(getName()=="container_cpu_usage_seconds_total", getValue() > 0.5)
     then
-        System.out.println("Metric1 rule fired");
+        System.out.println("Test resources Metric2 rule fired");
 end

--- a/src/test/resources/drools/test_test.drl
+++ b/src/test/resources/drools/test_test.drl
@@ -9,5 +9,5 @@ rule "Suggest Manager Role"
     when
         Metric()
     then
-        System.out.println("Rule fired");
+        System.out.println("Test resources test rule fired");
 end


### PR DESCRIPTION
# Fixed issue with loading drools file form resource.

Turned out that path in jar file is different from normal system path. Previously we read the files from relative directory in local environment. 

Chosen solution for this problem was to a add file `resources/META-INF/kmodule.xml` in which we define ksession with corresponing package (path relative to `resources`) with .drl files.

Then session can be obtained like this:
```java
KieContainer kc = this.kieServices.getKieClasspathContainer();
kc.newKieSession(this.sessionName);
```